### PR TITLE
Get raw response from Work Histories

### DIFF
--- a/lib/bob/api/employee/work_history.rb
+++ b/lib/bob/api/employee/work_history.rb
@@ -5,10 +5,9 @@ module Bob
     class WorkHistory < API
       def self.all(employee_id, include_raw: false)
         response = get("people/#{employee_id}/work")
-        parsed = WorkHistoryParser.new(response).work_histories
-        return { data: parsed, raw: response.values.first } if include_raw
+        return { raw: response.values.first } if include_raw
 
-        parsed
+        WorkHistoryParser.new(response).work_histories
       end
 
       def self.create(employee_id, params)

--- a/lib/bob/api/employee/work_history.rb
+++ b/lib/bob/api/employee/work_history.rb
@@ -3,9 +3,12 @@
 module Bob
   module Employee
     class WorkHistory < API
-      def self.all(employee_id)
+      def self.all(employee_id, include_raw: false)
         response = get("people/#{employee_id}/work")
-        WorkHistoryParser.new(response).work_histories
+        parsed = WorkHistoryParser.new(response).work_histories
+        return { data: parsed, raw: response.values.first } if include_raw
+
+        parsed
       end
 
       def self.create(employee_id, params)
@@ -13,10 +16,7 @@ module Bob
       end
 
       def self.update(employee_id, work_history_id, params)
-        put(
-          "people/#{employee_id}/work/#{work_history_id}",
-          params
-        )
+        put("people/#{employee_id}/work/#{work_history_id}", params)
       end
 
       def self.remove(employee_id, work_history_id)


### PR DESCRIPTION
Why?

- To update the work histories table the raw json needs to be the raw format provided by the .all method

What?

- This addition provides a flag `include_raw` which is true (DEFAULT: false), returns a hash of the parsed and raw data